### PR TITLE
Allow user to reload the ddg iframe based on user input

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,10 +1,24 @@
+// This will create/refresh the duckduckgo iframe and create it on first call
+function refresh_ddg_iframe(query, imageSearch, videoSearch){
+	if (!window.ddg_iframe){
+		window.ddg_iframe = document.createElement("iframe");
+		window.ddg_iframe.id = "duckduckgo-iframe";
+		document.body.appendChild(window.ddg_iframe)
+	}
+
+	if(query) {
+		window.ddg_iframe.src = "https://duckduckgo.com/?" + query + (imageSearch ? "&ia=images" : "") + (videoSearch ? "&ia=videos" : "");
+	}
+}
+
+// Initial state: get info from the URL
 const q = window.location.href.match(/q=[^&?#]*/);
 const imageSearch = /tbm=isch/.test(window.location.href);
 const videoSearch = /tbm=vid/.test(window.location.href);
+refresh_ddg_iframe(q, imageSearch, videoSearch);
 
-if(q) {
-	const iframe = document.createElement("iframe");
-	iframe.id = "duckduckgo-iframe";
-	iframe.src = "https://duckduckgo.com/?" + q + (imageSearch ? "&ia=images" : "") + (videoSearch ? "&ia=videos" : "");
-	document.body.appendChild(iframe)
-}
+// Use the Google input box to reload the ddg iframe
+const google_input_box = document.querySelector('input[name="q"]');
+google_input_box.addEventListener('change', _=>{
+	refresh_ddg_iframe('q='+google_input_box.value, null, null);
+});


### PR DESCRIPTION
Refactoring and splitting of the code to allow a reload of the ddg
iframe when the user input something on the google search box. This works
like the previous version, but use an input's value instead of a pattern
in the URL.

Demo: 

![demo](https://media.giphy.com/media/rKCgF4XunBwWI/giphy.gif)